### PR TITLE
Fix save/load all electrodes

### DIFF
--- a/SEEGAtlas/NameInputDialog.ui
+++ b/SEEGAtlas/NameInputDialog.ui
@@ -7,44 +7,64 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>169</height>
+    <height>138</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <widget class="QWidget" name="layoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>30</y>
-     <width>361</width>
-     <height>85</height>
-    </rect>
-   </property>
-   <layout class="QFormLayout" name="formLayout">
-    <item row="0" column="0">
-     <widget class="QLabel" name="label">
-      <property name="text">
-       <string>Enter Electrode's Name</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0" colspan="2">
-     <widget class="QLineEdit" name="lineEditName"/>
-    </item>
-    <item row="2" column="1">
-     <widget class="QDialogButtonBox" name="buttonBox">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="standardButtons">
-       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Enter Electrode's Name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QLineEdit" name="lineEditName">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>23</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="minimumSize">
+        <size>
+         <width>216</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>7</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections>

--- a/SEEGAtlas/SEEGAtlasWidget.cpp
+++ b/SEEGAtlas/SEEGAtlasWidget.cpp
@@ -326,10 +326,10 @@ void SEEGAtlasWidget::OnObjectRemovedSlot(int imageObjectId)
 void SEEGAtlasWidget::CreateAllElectrodes(bool showProgress) {
     
     // This progress bar does not reflect the real progress
-    // it assumes (arbitrarily) 30 electrodes and loops until all electrodes are loaded
+    // it assumes (arbitrarily) MAX_VISIBLE_PLANS electrodes and loops until all electrodes are loaded
     Q_ASSERT(m_pluginInterface);
     IbisAPI * ibisApi = m_pluginInterface->GetIbisAPI();
-    int progressMax = 30;
+    int progressMax = MAX_VISIBLE_PLANS;
     QProgressDialog * progress;
     if( showProgress ) progress = ibisApi->StartProgress(progressMax, "Creating electrodes");
 

--- a/SEEGAtlas/seegplanning/ElectrodeInfo.cpp
+++ b/SEEGAtlas/seegplanning/ElectrodeInfo.cpp
@@ -41,7 +41,8 @@ ElectrodeInfo::ElectrodeInfo(const Point3D& entryPointWorld, const Point3D& targ
     v.z = m_EntryPointWorld[2] - m_TargetPointWorld[2];
     float d = norm(v);
     m_ElectrodeVectorWorld = v/d; // unit vector
-    m_ElectrodeModel = electrodeModel;
+    m_ElectrodeModel = SEEGElectrodeModel::New();
+    m_ElectrodeModel->DeepCopy(electrodeModel);
     m_ElectrodeName = electrodeName;
     m_Valid = false;
 }
@@ -75,7 +76,7 @@ seeg::SEEGElectrodeModel::Pointer ElectrodeInfo::GetElectrodeModel()
 }
 
 void ElectrodeInfo::SetElectrodeModel(seeg::SEEGElectrodeModel::Pointer electrodeModel){
-    m_ElectrodeModel = electrodeModel;
+    m_ElectrodeModel->DeepCopy(electrodeModel);
 }
 
 seeg::Vector3D_lf ElectrodeInfo::GetElectrodeVectorWorld(){
@@ -393,11 +394,11 @@ bool ElectrodeInfo::LoadElectrodeDataFromFile (const string& filename, const cha
 void ElectrodeInfo::SaveElectrodeDataToFile(const string& filename, const char delimiter){
     // Saves best trajectory
     cout<<"Saving All Electrodes information to "<<filename<< endl;
-    seeg::SEEGElectrodeModel::Pointer electModel;
+    seeg::SEEGElectrodeModel::Pointer electModel = m_ElectrodeModel;
     ofstream file;
     file.open(filename.c_str());
     file << "[fileType]"<< delimiter<< "Electrode" << endl;
-    file << "[electrodeType]"<< delimiter<< electModel->GetElectrodeName() << endl;
+    file << "[electrodeType]"<< delimiter<< electModel->GetElectrodeId() << endl;
     file << "[trajectory]"<< delimiter;
     file << m_ElectrodeName.c_str() << delimiter;
     file << m_TargetPointWorld[0] << delimiter;

--- a/SEEGAtlas/seegplanning/SEEGElectrodeModel.cpp
+++ b/SEEGAtlas/seegplanning/SEEGElectrodeModel.cpp
@@ -203,6 +203,24 @@ namespace seeg {
 
     }
 
+    void SEEGElectrodeModel::DeepCopy(const SEEGElectrodeModel::Pointer model)
+    {
+        if( this == model.get() ) return;
+
+        this->m_ElectrodeId = model->m_ElectrodeId;
+        this->m_ElectrodeName = model->m_ElectrodeName;
+        this->m_TipContactHeight = model->m_TipContactHeight;
+        this->m_recordingRadius = model->m_recordingRadius;
+        this->m_PegHeight = model->m_PegHeight;
+        this->m_PegDiameter = model->m_PegDiameter;
+        this->m_ContactDiameter = model->m_ContactDiameter;
+        this->m_ContactHeight = model->m_ContactHeight;
+        this->m_ContactSpacing = model->m_ContactSpacing;
+        this->m_NumContacts = model->m_NumContacts;
+        this->m_TipOffset = model->m_TipOffset;
+
+    }
+
     void SEEGElectrodeModel::Serialize(Serializer * ser)
     {
         ::Serialize(ser, "ElectrodeId", m_ElectrodeId);

--- a/SEEGAtlas/seegplanning/SEEGElectrodeModel.h
+++ b/SEEGAtlas/seegplanning/SEEGElectrodeModel.h
@@ -138,6 +138,8 @@ public:
 
     float CalcDistFromTipToChannelCenter(unsigned int contact_index);
 
+    void DeepCopy(const SEEGElectrodeModel::Pointer model);
+
 };
 
 ObjectSerializationHeaderMacro(SEEGElectrodeModel);

--- a/SEEGAtlas/seegplanning/SEEGElectrodesCohort.cpp
+++ b/SEEGAtlas/seegplanning/SEEGElectrodesCohort.cpp
@@ -123,16 +123,16 @@ namespace seeg {
         // change also in each electrode in best cohort
         map<string, ElectrodeInfo::Pointer> bestCohort = GetBestCohort();
 
-        // Get bounding box of each electrode
-        map<string, ElectrodeInfo::Pointer>::const_iterator it1;
-        int iElec;
-        for (iElec=0,it1 = bestCohort.begin(); it1 != bestCohort.end(); iElec++,it1++) {
-            ElectrodeInfo::Pointer electrode = it1->second;
-            if( electrode )
-            {
-                electrode->SetElectrodeModel(electrodeModel);
-            }
-        }
+        //// Get bounding box of each electrode
+        //map<string, ElectrodeInfo::Pointer>::const_iterator it1;
+        //int iElec;
+        //for (iElec=0,it1 = bestCohort.begin(); it1 != bestCohort.end(); iElec++,it1++) {
+        //    ElectrodeInfo::Pointer electrode = it1->second;
+        //    if( electrode )
+        //    {
+        //        electrode->SetElectrodeModel(electrodeModel);
+        //    }
+        //}
     }
 
     /*** Points along trajectory ***/

--- a/SEEGAtlas/seegplanning/SEEGFileHelper.h
+++ b/SEEGAtlas/seegplanning/SEEGFileHelper.h
@@ -194,7 +194,7 @@ namespace seeg {
 //CHANNELS
 #define FILE_CHANNELS_GRAL "channels_"
 
-#define MAX_SEEG_PLANS 1000 //before: 20 //INCREASE to generalize!
+#define MAX_SEEG_PLANS 100 //before: 20 //INCREASE to generalize!
 #define MAX_VISIBLE_PLANS 20 // now separate the number of plans in combo (to mark in each patient to the total number (e.g. to visualize in atlas)
 
 /************** PUBLIC TYPE DEFINITION *****************************/


### PR DESCRIPTION
Fix bug when save and load electrodes
- Initially, all electrodes in the cohort (i.e., SEEGElectrodesCohort::BestCohort) have the same electrode info, which implies that all implanted electrodes have the same ElectrodeModel. This creates discrepancy when saving electrodes of different models. New functionality -> do not copy ElectrodeInfo to all Cohort when setting new electrode model.
- Electrode type was wrong in .csv files  
- Use deep copy of electrode model to avoid wrong pointer manipulation 
- Fix minor UI 