### PR TITLE
track model representation per cohor

### DIFF
--- a/SEEGAtlas/SEEGAtlasWidget.h
+++ b/SEEGAtlas/SEEGAtlasWidget.h
@@ -36,10 +36,15 @@ struct CylinderDisplay {
 };
 
 struct ElectrodeDisplay{
+    bool defined;
     CylinderDisplay m_ElectrodeDisplay;
     std::vector<CylinderDisplay> m_ContactsDisplay;
     seeg::SEEGElectrodeModel::Pointer m_ElectrodeModel;
     seeg::SEEGPointRepresentation::Pointer m_PointRepresentation;
+
+    ElectrodeDisplay() {
+        defined = false;
+    }
 };
 
 

--- a/SEEGAtlas/seegplanning/SEEGElectrodesCohort.cpp
+++ b/SEEGAtlas/seegplanning/SEEGElectrodesCohort.cpp
@@ -121,7 +121,7 @@ namespace seeg {
     void SEEGElectrodesCohort::SetElectrodeModel(SEEGElectrodeModel::Pointer electrodeModel){
         m_ElectrodeModel = electrodeModel; //assign type of electrode to cohort
         // change also in each electrode in best cohort
-        map<string, ElectrodeInfo::Pointer> bestCohort = GetBestCohort();
+        //map<string, ElectrodeInfo::Pointer> bestCohort = GetBestCohort();
 
         //// Get bounding box of each electrode
         //map<string, ElectrodeInfo::Pointer>::const_iterator it1;


### PR DESCRIPTION
Previous behaviour:
- forces all the electrodes (in saved plans) to have the same model in the visualization
- when model (i.e. electrode type) is changed it affects all 3D visualization of all saved electrodes
- this doesn't change information in contact table (contact data that are saved are still valid)

Proposed/new behaviour:
- associates the electrode model to the each saved electrode (stored in ElectrodeInfo in SEEGElectrodeCohor) 
- the association is made via electrode name
- if a contact position is changed, it is stored in ElectrodeInfo in the cohort, which is then used for visualization (this ensures to keep up-to-date coordinates)